### PR TITLE
Fix version in package.json

### DIFF
--- a/reactjs/package.json
+++ b/reactjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SystemSeed",
-  "version": "1.0",
+  "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
     "compression": "^1.7.3",


### PR DESCRIPTION
From the [docs](https://docs.npmjs.com/getting-started/using-a-package.json#requirements): `version` should be  `in the form of x.x.x`.